### PR TITLE
Configure to run armor on aws runner

### DIFF
--- a/.github/workflows/run_armor.yml
+++ b/.github/workflows/run_armor.yml
@@ -26,7 +26,9 @@ permissions:
 
 jobs:
   RUN-ARMOR:
-    runs-on: ubuntu-22.04
+    runs-on:
+      group: GHA-CSEPerf-prd-SelfHosted-RG
+      labels: [self-hosted, cseperf-prd-u2204-arm64-xlrg-od-ephem]
     steps:
       - uses: actions/checkout@v4
       - name: Set event variables


### PR DESCRIPTION
Use aws runners in run_armor workflow, which is need to upload artifacts generated in RUN-ARMOR workflow to s3 location