### PR TITLE
Optimize libRestuneCore memory footprint using linker version script

### DIFF
--- a/resource-tuner/CMakeLists.txt
+++ b/resource-tuner/CMakeLists.txt
@@ -40,6 +40,18 @@ endif()
 
 add_library(RestuneCore ${SOURCES})
 
+# Convert build type to uppercase for case-insensitive comparison 
+# Handles variations like "Debug", "DEBUG", "debug" consistently
+string(TOUPPER "${CMAKE_BUILD_TYPE}" UPPER_BUILD_TYPE)
+
+# Apply linker version script for Release builds only (excludes Debug and Test builds)
+# Controls symbol visibility to reduce memory footprint and library size
+if(NOT BUILD_TESTS AND NOT UPPER_BUILD_TYPE STREQUAL "DEBUG")
+	target_link_options(RestuneCore PRIVATE 
+    	"-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libRestuneCore.map"
+	)
+endif()
+
 set_target_properties(RestuneCore PROPERTIES VERSION 1.0.0 SOVERSION 1)
 target_link_libraries(RestuneCore PUBLIC ${LINK_LIBS})
 

--- a/resource-tuner/libRestuneCore.map
+++ b/resource-tuner/libRestuneCore.map
@@ -1,0 +1,50 @@
+URM_CORE_1.0 {
+    global:
+        # --- Public C API ---
+        Restune_Init;
+        Restune_Deinit;
+
+        # --- C++ Classes & Functions ---
+        extern "C++" {
+            # 1. Previously Identified
+            RestuneParser::parse*;
+            *TargetRegistry*;
+            *ResourceRegistry*;
+            *submitPropGetRequest*;
+            *PulseMonitor*;
+
+            # 2. ADDED: Missing Singletons & Registries
+            *CocoTable*;
+            *RequestQueue*;
+            *ExtFeaturesRegistry*;
+            *RequestReceiver*;
+
+            # 3. ADDED: Thread & Daemon Functions
+            startClientGarbageCollectorDaemon*;
+            stopClientGarbageCollectorDaemon*;
+            listenerThreadStartRoutine*;
+
+	        # ADD THESE SPECIFIC EXPORTS:
+            "SignalRegistry::getInstance()";
+            "SignalRegistry::getSignalConfigById(unsigned int, unsigned int)";
+            "SignalRegistry::getSignalConfigById(unsigned long)";
+        
+            # Export the static member variable
+            "SignalRegistry::signalRegistryInstance";
+        
+            # Add other dependencies
+            *AuxRoutines*;
+            *submitResProvisionRequest*;
+            *Request*;
+            *Signal*;
+            *Logger*;
+            *AppConfigs*;
+            *ClientGarbageCollector*;
+            *ClientDataManager*;
+        };
+
+    local:
+        # Hide everything else
+        *;
+};
+


### PR DESCRIPTION
Changes Made:
* Introduced 'libRestuneCore.map' to enforce strict symbol scoping at the linker level ('ld --version-script').
* Explicitly whitelisted necessary globals ('RestuneParser', 'CocoTable', 'RequestQueue', etc.) while demoting all other symbols to 'local'.
* Test & Debug Compatibility (If Condition): Added conditional logic to only apply the linker script when not building tests or in debug mode. Because the version script aggressively hides internal C++ classes (like 'ClientDataManager' and 'RateLimiter'), our component tests (RestuneComponentTests) will fail to link against them. This condition ensures tests and debugging continue to work normally while optimizing the production release build.
