### PR TITLE
Add RAM-based configurable thread stack size

### DIFF
--- a/modula/Components/Include/ThreadPool.h
+++ b/modula/Components/Include/ThreadPool.h
@@ -40,6 +40,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <exception>
+#include <pthread.h>
 
 #include "Utils.h"
 #include "Logger.h"
@@ -58,6 +59,8 @@ public:
 
 struct ThreadNode {
     std::thread* th;
+    pthread_t pthreadHandle;  // Store pthread handle when using custom stack size
+    int8_t usePthread;        // Flag to indicate if pthread is used
     ThreadNode* next;
 };
 
@@ -88,6 +91,7 @@ class ThreadPool {
 private:
     int32_t mDesiredPoolCapacity; //!< Desired or Base Thread Pool Capacity
     int32_t mMaxPoolCapacity; //!< Max Capacity upto which the Thread Pool can scale up.
+    size_t mThreadStackSize; //!< Stack size for each thread in bytes
 
     int32_t mCurrentThreadsCount;
     int32_t mTotalTasksCount;
@@ -105,7 +109,13 @@ private:
     int8_t threadRoutineHelper(int8_t isCoreThread);
 
 public:
-    ThreadPool(int32_t desiredCapacity, int32_t maxCapacity);
+    /**
+     * @brief Construct a new Thread Pool object
+     * @param desiredCapacity Desired number of threads in the pool
+     * @param maxCapacity Maximum capacity the pool can scale to
+     * @param stackSize Stack size for each thread in bytes (default: 0 = system default)
+     */
+    ThreadPool(int32_t desiredCapacity, int32_t maxCapacity, size_t stackSize = 0);
     ~ThreadPool();
 
     /**

--- a/modula/Components/ThreadPool.cpp
+++ b/modula/Components/ThreadPool.cpp
@@ -147,6 +147,9 @@ int8_t ThreadPool::addNewThread(int8_t isCoreThread) {
     }
 
     thNode->next = nullptr;
+    thNode->th = nullptr;
+    thNode->pthreadHandle = 0;
+    thNode->usePthread = 0;
 
     try {
         auto threadStartRoutine = ([this](int8_t isCoreThread) {
@@ -158,7 +161,56 @@ int8_t ThreadPool::addNewThread(int8_t isCoreThread) {
         });
 
         try {
-            thNode->th = new std::thread(threadStartRoutine, isCoreThread);
+            // If custom stack size is specified, use pthread directly
+            if(this->mThreadStackSize > 0) {
+                pthread_attr_t attr;
+                if(pthread_attr_init(&attr) != 0) {
+                    FreeBlock<ThreadNode>(static_cast<void*>(thNode));
+                    throw std::system_error(errno, std::system_category(), "pthread_attr_init failed");
+                }
+
+                if(pthread_attr_setstacksize(&attr, this->mThreadStackSize) != 0) {
+                    pthread_attr_destroy(&attr);
+                    FreeBlock<ThreadNode>(static_cast<void*>(thNode));
+                    throw std::system_error(errno, std::system_category(), "pthread_attr_setstacksize failed");
+                }
+
+                // Create a wrapper structure to pass both this pointer and isCoreThread
+                struct ThreadArgs {
+                    ThreadPool* pool;
+                    int8_t isCoreThread;
+                };
+
+                ThreadArgs* args = new ThreadArgs{this, isCoreThread};
+
+                int result = pthread_create(&thNode->pthreadHandle, &attr,
+                    [](void* arg) -> void* {
+                        ThreadArgs* targs = static_cast<ThreadArgs*>(arg);
+                        ThreadPool* pool = targs->pool;
+                        int8_t isCoreThread = targs->isCoreThread;
+                        delete targs;
+
+                        while(true) {
+                            if(pool->threadRoutineHelper(isCoreThread)) {
+                                return nullptr;
+                            }
+                        }
+                    }, args);
+
+                pthread_attr_destroy(&attr);
+
+                if(result != 0) {
+                    delete args;
+                    FreeBlock<ThreadNode>(static_cast<void*>(thNode));
+                    throw std::system_error(result, std::system_category(), "pthread_create failed");
+                }
+
+                thNode->usePthread = 1;
+            } else {
+                // Use default std::thread creation
+                thNode->th = new std::thread(threadStartRoutine, isCoreThread);
+                thNode->usePthread = 0;
+            }
 
         } catch(const std::system_error& e) {
             FreeBlock<ThreadNode>(static_cast<void*>(thNode));
@@ -187,11 +239,12 @@ int8_t ThreadPool::addNewThread(int8_t isCoreThread) {
     return false;
 }
 
-ThreadPool::ThreadPool(int32_t desiredCapacity, int32_t maxCapacity) {
+ThreadPool::ThreadPool(int32_t desiredCapacity, int32_t maxCapacity, size_t stackSize) {
     this->mThreadQueueHead = this->mThreadQueueTail = nullptr;
 
     this->mDesiredPoolCapacity = desiredCapacity;
     this->mCurrentThreadsCount = 0;
+    this->mThreadStackSize = stackSize;
 
     if(maxCapacity < desiredCapacity) {
         maxCapacity = desiredCapacity;
@@ -225,7 +278,8 @@ ThreadPool::ThreadPool(int32_t desiredCapacity, int32_t maxCapacity) {
 
     LOGI("RESTUNE_THREAD_POOL",
          "Requested Thread Count = " + std::to_string(this->mDesiredPoolCapacity) + ", "  \
-         "Allocated Thread Count = " + std::to_string(this->mCurrentThreadsCount));
+         "Allocated Thread Count = " + std::to_string(this->mCurrentThreadsCount) + ", " \
+         "Stack Size = " + std::to_string(this->mThreadStackSize) + " bytes");
 
     this->mDesiredPoolCapacity = this->mCurrentThreadsCount;
 }
@@ -327,8 +381,16 @@ ThreadPool::~ThreadPool() {
             ThreadNode* nextNode = thNode->next;
 
             try {
-                if(thNode->th != nullptr && thNode->th->joinable()) {
-                    thNode->th->join();
+                if(thNode->usePthread) {
+                    // Join pthread
+                    if(thNode->pthreadHandle != 0) {
+                        pthread_join(thNode->pthreadHandle, nullptr);
+                    }
+                } else {
+                    // Join std::thread
+                    if(thNode->th != nullptr && thNode->th->joinable()) {
+                        thNode->th->join();
+                    }
                 }
             } catch(const std::exception& e) {}
 

--- a/resource-tuner/init/RestuneInit.cpp
+++ b/resource-tuner/init/RestuneInit.cpp
@@ -6,6 +6,10 @@
 #include <string>
 #include <thread>
 #include <memory>
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+#include <pthread.h>
 
 #include "Config.h"
 #include "ErrCodes.h"
@@ -77,6 +81,49 @@ static ErrCode loadExtensionsLib() {
         TYPELOGV(NOTIFY_EXTENSIONS_LIB_LOADED_SUCCESS, libsLoaded);
     }
     return RC_SUCCESS;
+}
+
+static uint64_t readTotalRamBytes() {
+    std::ifstream meminfo("/proc/meminfo");
+    std::string line;
+
+    while(std::getline(meminfo, line)) {
+        if(line.rfind("MemTotal:", 0) == 0) {
+            std::istringstream iss(line);
+            std::string key;
+            uint64_t memTotalKb = 0;
+            std::string unit;
+            iss >> key >> memTotalKb >> unit;
+            return memTotalKb * 1024ULL;
+        }
+    }
+
+    return 0ULL;
+}
+
+static size_t getConfiguredThreadStackSizeBytes() {
+    uint64_t ramBytes = readTotalRamBytes();
+    size_t stackSize = 16ULL * 1024ULL * 1024ULL;
+
+    if(ramBytes < (1ULL * 1024ULL * 1024ULL * 1024ULL)) {
+        stackSize = 2ULL * 1024ULL * 1024ULL;
+    } else if(ramBytes < (4ULL * 1024ULL * 1024ULL * 1024ULL)) {
+        stackSize = 4ULL * 1024ULL * 1024ULL;
+    } else if(ramBytes < (8ULL * 1024ULL * 1024ULL * 1024ULL)) {
+        stackSize = 8ULL * 1024ULL * 1024ULL;
+    }
+
+    size_t finalStackSize = std::max(stackSize, (size_t)PTHREAD_STACK_MIN);
+
+    // Log the RAM size and configured stack size
+    uint64_t ramMB = ramBytes / (1024ULL * 1024ULL);
+    uint64_t stackMB = finalStackSize / (1024ULL * 1024ULL);
+    LOGI("RESTUNE_THREAD_STACK",
+         "Total RAM: " + std::to_string(ramMB) + " MB, " \
+         "Configured Thread Stack Size: " + std::to_string(stackMB) + " MB (" + \
+         std::to_string(finalStackSize) + " bytes)");
+
+    return finalStackSize;
 }
 
 static void preAllocateMemory() {
@@ -425,14 +472,17 @@ static ErrCode fetchPerAppConfigs() {
 static ErrCode preAllocateWorkers() {
     uint32_t desiredThreadCapacity = UrmSettings::metaConfigs.mDesiredThreadCount;
     uint32_t maxScalingCapacity = UrmSettings::metaConfigs.mMaxScalingCapacity;
+    size_t threadStackSize = getConfiguredThreadStackSizeBytes();
 
     try {
         RequestReceiver::mRequestsThreadPool = new ThreadPool(desiredThreadCapacity,
-                                                              maxScalingCapacity);
+                                                              maxScalingCapacity,
+                                                              threadStackSize);
 
         // Allocate 2 extra threads for Pulse Monitor and Garbage Collector
         Timer::mTimerThreadPool = new ThreadPool(desiredThreadCapacity + 2,
-                                                 maxScalingCapacity);
+                                                 maxScalingCapacity,
+                                                 threadStackSize);
 
     } catch(const std::bad_alloc& e) {
         TYPELOGV(THREAD_POOL_CREATION_FAILURE, e.what());


### PR DESCRIPTION
This PR implements dynamic thread stack size based on system RAM.

Changes
- Reads system RAM from /proc/meminfo
- Configures stack size: <1GB→2MB, <4GB→4MB, <8GB→8MB, ≥8GB→16MB
- Uses pthread for custom stack sizes