### PR TITLE
urm.service: start earlier in userspace

### DIFF
--- a/urm.service.in
+++ b/urm.service.in
@@ -1,10 +1,12 @@
 [Unit]
 Description=URM Service
+After=sysinit.target
+Before=multi-user.target
 
 [Service]
 Restart=on-failure
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/urm
-ExecStartPost=-/etc/urm/initscripts/post_boot/post_boot.sh
+ExecStartPre=-/etc/urm/initscripts/post_boot/post_boot.sh
 TimeoutStopSec=2
 Delegate=yes
 Slice=urm.slice

--- a/urm.service.in
+++ b/urm.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=URM Service
-After=sysinit.target
+DefaultDependencies=no
 Before=multi-user.target
 
 [Service]
@@ -12,4 +12,4 @@ Delegate=yes
 Slice=urm.slice
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sysinit.target multi-user.target

--- a/urm.service.in
+++ b/urm.service.in
@@ -1,7 +1,6 @@
 [Unit]
 Description=URM Service
-After=sysinit.target
-Before=multi-user.target
+DefaultDependencies=no
 
 [Service]
 Restart=on-failure
@@ -12,4 +11,4 @@ Delegate=yes
 Slice=urm.slice
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sysinit.target multi-user.target


### PR DESCRIPTION
Post-boot service is responsible for applying system tunings. 
To ensure tunings take effect as early as possible, align URM service startup with early userspace initialization.