### PR TITLE
Change placeholder value to int_min

### DIFF
--- a/modula/Components/Logger.cpp
+++ b/modula/Components/Logger.cpp
@@ -428,7 +428,7 @@ void Logger::typeLog(CommonMessageTypes type, const std::string& funcName, ...) 
 
         case CommonMessageTypes::VERIFIER_INVALID_OPCODE:
             vsnprintf(buffer, sizeof(buffer),
-                      "Invalid Opcode [%u], Dropping Request.", args);
+                      "Invalid Opcode [0x%08x], Dropping Request.", args);
 
             Logger::log(LOG_ERR, "URM_REQUEST_VERIFIER", funcName, buffer);
             break;

--- a/resource-tuner/core/Include/ResourceRegistry.h
+++ b/resource-tuner/core/Include/ResourceRegistry.h
@@ -8,11 +8,11 @@
 #include <memory>
 #include <unordered_map>
 
-#include "UrmPlatformAL.h"
+#include "Utils.h"
+#include "Logger.h"
 #include "Resource.h"
 #include "Extensions.h"
-#include "Logger.h"
-#include "Utils.h"
+#include "UrmPlatformAL.h"
 
 /**
  * @struct ResourceApplyType

--- a/resource-tuner/core/RequestHandler.cpp
+++ b/resource-tuner/core/RequestHandler.cpp
@@ -76,8 +76,10 @@ static ErrCode translateToPhysicalIDs(Resource* resource) {
             // Perform logical to physical mapping here, as part of which verification can happen
             // Replace mResInfo with the Physical values here:
             if(!performPhysicalMapping(coreValue, clusterValue)) {
-                TYPELOGV(VERIFIER_LOGICAL_TO_PHYSICAL_MAPPING_FAILED, resource->getResCode());
-                return RC_INVALID_VALUE;
+                if(rConf->mPolicy != Policy::PASS_THROUGH) {
+                    TYPELOGV(VERIFIER_LOGICAL_TO_PHYSICAL_MAPPING_FAILED, resource->getResCode());
+                    return RC_INVALID_VALUE;
+                }
             }
 
             resource->setCoreValue(coreValue);
@@ -95,10 +97,13 @@ static ErrCode translateToPhysicalIDs(Resource* resource) {
 
             // Perform logical to physical mapping here, as part of which verification can happen
             // Replace mResInfo with the Physical values here:
-            int32_t physicalClusterID = TargetRegistry::getInstance()->getPhysicalClusterId(clusterValue);
+            int32_t physicalClusterID =
+                TargetRegistry::getInstance()->getPhysicalClusterId(clusterValue);
             if(physicalClusterID == -1) {
-                TYPELOGV(VERIFIER_LOGICAL_TO_PHYSICAL_MAPPING_FAILED, resource->getResCode());
-                return RC_INVALID_VALUE;
+                if(rConf->mPolicy != Policy::PASS_THROUGH) {
+                    TYPELOGV(VERIFIER_LOGICAL_TO_PHYSICAL_MAPPING_FAILED, resource->getResCode());
+                    return RC_INVALID_VALUE;
+                }
             }
 
             resource->setClusterValue(physicalClusterID);

--- a/resource-tuner/signals/Include/SignalRegistry.h
+++ b/resource-tuner/signals/Include/SignalRegistry.h
@@ -16,6 +16,8 @@
 #include "UrmPlatformAL.h"
 #include "SignalInternal.h"
 
+#define NSIG_PLACEHOLDER std::numeric_limits<int>::min()
+
 /**
  * @struct SignalInfo
  * @brief Representation of a single Signal Configuration

--- a/resource-tuner/signals/SignalHandler.cpp
+++ b/resource-tuner/signals/SignalHandler.cpp
@@ -139,7 +139,7 @@ static Request* createResourceTuningRequest(Signal* signal) {
 
             // fill placeholders if any
             for(int32_t j = 0; j < resource->getValuesCount(); j++) {
-                if(resource->getValueAt(j) == -1) {
+                if(resource->getValueAt(j) == NSIG_PLACEHOLDER) {
                     if(signal->getListArgs() == nullptr) return nullptr;
                     if(listIndex >= 0 && listIndex < signal->getNumArgs()) {
                         resource->setValueAt(j, signal->getListArgAt(listIndex));
@@ -364,7 +364,7 @@ static Request* createTuneRequestFromSignal(uint32_t sigId,
             // fill placeholders if any
             int32_t listIndex = 0;
             for(int32_t j = 0; j < resource->getValuesCount(); j++) {
-                if(resource->getValueAt(j) == -1) {
+                if(resource->getValueAt(j) == NSIG_PLACEHOLDER) {
                     if(args == nullptr) return nullptr;
                     if(listIndex >= 0 && listIndex < numArgs) {
                         resource->setValueAt(j, args[listIndex]);

--- a/resource-tuner/signals/SignalRegistry.cpp
+++ b/resource-tuner/signals/SignalRegistry.cpp
@@ -520,7 +520,7 @@ ErrCode ResourceBuilder::addValue(int32_t index, const std::string& valueString)
         return RC_MEMORY_ALLOCATION_FAILURE;
     }
 
-    int32_t value = -1;
+    int32_t value = NSIG_PLACEHOLDER;
 
     // Check if the value is a placeholder, i.e. the actual value will be populated
     // dynamically at runtime via the "list" argument passed to tuneSignal API.

--- a/tests/Component/ParserTests.cpp
+++ b/tests/Component/ParserTests.cpp
@@ -180,16 +180,16 @@ URM_TEST(SignalParsingTests, {
         Resource* resource1 = signalInfo->mSignalResources->at(0);
         E_ASSERT((resource1->getResCode() == 0x000900aa));
         E_ASSERT((resource1->getValuesCount() == 3));
-        E_ASSERT((resource1->getValueAt(0) == -1));
-        E_ASSERT((resource1->getValueAt(1) == -1));
+        E_ASSERT((resource1->getValueAt(0) == NSIG_PLACEHOLDER));
+        E_ASSERT((resource1->getValueAt(1) == NSIG_PLACEHOLDER));
         E_ASSERT((resource1->getValueAt(2) == 68));
         E_ASSERT((resource1->getResInfo() == 0));
 
         Resource* resource2 = signalInfo->mSignalResources->at(1);
         E_ASSERT((resource2->getResCode() == 0x000900dc));
         E_ASSERT((resource2->getValuesCount() == 4));
-        E_ASSERT((resource2->getValueAt(0) == -1));
-        E_ASSERT((resource2->getValueAt(1) == -1));
+        E_ASSERT((resource2->getValueAt(0) == NSIG_PLACEHOLDER));
+        E_ASSERT((resource2->getValueAt(1) == NSIG_PLACEHOLDER));
         E_ASSERT((resource2->getValueAt(2) == 50));
         E_ASSERT((resource2->getValueAt(3) == 512));
         E_ASSERT((resource2->getResInfo() == 0));
@@ -781,16 +781,16 @@ URM_TEST(SignalParsingTestsAddOn, {
         Resource* resource1 = signalInfo->mSignalResources->at(0);
         E_ASSERT((resource1->getResCode() == 0x000900aa));
         E_ASSERT((resource1->getValuesCount() == 3));
-        E_ASSERT((resource1->getValueAt(0) == -1));
-        E_ASSERT((resource1->getValueAt(1) == -1));
+        E_ASSERT((resource1->getValueAt(0) == NSIG_PLACEHOLDER));
+        E_ASSERT((resource1->getValueAt(1) == NSIG_PLACEHOLDER));
         E_ASSERT((resource1->getValueAt(2) == 68));
         E_ASSERT((resource1->getResInfo() == 0));
 
         Resource* resource2 = signalInfo->mSignalResources->at(1);
         E_ASSERT((resource2->getResCode() == 0x000900dc));
         E_ASSERT((resource2->getValuesCount() == 4));
-        E_ASSERT((resource2->getValueAt(0) == -1));
-        E_ASSERT((resource2->getValueAt(1) == -1));
+        E_ASSERT((resource2->getValueAt(0) == NSIG_PLACEHOLDER));
+        E_ASSERT((resource2->getValueAt(1) == NSIG_PLACEHOLDER));
         E_ASSERT((resource2->getValueAt(2) == 50));
         E_ASSERT((resource2->getValueAt(3) == 512));
         E_ASSERT((resource2->getResInfo() == 0));


### PR DESCRIPTION
Using a value of -1 as placeholder intereferes with Signal which actually want to configure the value of -1 for any Resource. As part of this changeset, the placeholder value is modified to INT_MIN (32-bit), which should be suitable for almost all scenarios.