### PR TITLE
Fix zizmor GitHub Actions security findings

### DIFF
--- a/.github/actions/aws_s3_helper/action.yml
+++ b/.github/actions/aws_s3_helper/action.yml
@@ -41,54 +41,60 @@ runs:
       id: sync-data
       shell: bash
       env:
+        MODE: ${{ inputs.mode }}
+        S3_BUCKET: ${{ inputs.s3_bucket }}
+        LOCAL_FILE: ${{ inputs.local_file }}
+        DOWNLOAD_FILE: ${{ inputs.download_file }}
+        DOWNLOAD_LOCATION: ${{ inputs.download_location }}
         UPLOAD_LOCATION: ${{ inputs.upload_location }}
+        WORKSPACE: ${{ github.workspace }}
       run: |
         echo "::group::$(printf '__________ %-100s' 'Process' | tr ' ' _)"
-        case "${{ inputs.mode }}" in
+        case "$MODE" in
           multi-upload)
             echo "Uploading files to S3 bucket..."
             first_line=true
             # Start the JSON object
-            echo "{" > ${{ github.workspace }}/presigned_urls.json
+            echo "{" > "$WORKSPACE/presigned_urls.json"
             while IFS= read -r file; do
               if [ -f "$file" ]; then
                 echo "Uploading $file..."
-                aws s3 cp "$file" s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}/
-                echo "Uploaded $file to s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}"
+                aws s3 cp "$file" "s3://$S3_BUCKET/$UPLOAD_LOCATION/"
+                echo "Uploaded $file to s3://$S3_BUCKET/$UPLOAD_LOCATION"
                 echo "Creating Pre-signed URL for $file..."
                 filename=$(basename "$file")
-                presigned_url=$(aws s3 presign s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}/$filename --expires-in 259200)
+                presigned_url=$(aws s3 presign "s3://$S3_BUCKET/$UPLOAD_LOCATION/$filename" --expires-in 259200)
                 if [ "$first_line" = true ]; then
                   first_line=false
                 else
-                  echo "," >> ${{ github.workspace }}/presigned_urls.json
+                  echo "," >> "$WORKSPACE/presigned_urls.json"
                 fi
                 # Append the pre-signed URL to the file
-                echo " \"${file}\": \"${presigned_url}\"" >> ${{ github.workspace }}/presigned_urls.json
+                echo " \"${file}\": \"${presigned_url}\"" >> "$WORKSPACE/presigned_urls.json"
                 echo "Pre-signed URL for $file: $presigned_url"
               else
                 echo "Warning: $file does not exist or is not a regular file."
               fi
-            done < "${{ inputs.local_file }}"
+            done < "$LOCAL_FILE"
             # Close the JSON object
-            echo "}" >> ${{ github.workspace }}/presigned_urls.json
+            echo "}" >> "$WORKSPACE/presigned_urls.json"
             ;;
           single-upload)
             echo "Uploading single file to S3 bucket..."
-            aws s3 cp "${{ inputs.local_file }}" s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}/
-            echo "Uploaded ${{ inputs.local_file }} to s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}"
-            echo "Creating Pre-signed URL for ${{ inputs.local_file }}..."
-            presigned_url=$(aws s3 presign s3://${{ inputs.s3_bucket }}/${{ env.UPLOAD_LOCATION }}/${{ inputs.local_file }} --expires-in 259200)
+            aws s3 cp "$LOCAL_FILE" "s3://$S3_BUCKET/$UPLOAD_LOCATION/"
+            echo "Uploaded $LOCAL_FILE to s3://$S3_BUCKET/$UPLOAD_LOCATION"
+            echo "Creating Pre-signed URL for $LOCAL_FILE..."
+            presigned_url=$(aws s3 presign "s3://$S3_BUCKET/$UPLOAD_LOCATION/$LOCAL_FILE" --expires-in 259200)
             echo "presigned_url=${presigned_url}" >> "$GITHUB_OUTPUT"
             ;;
           download)
             #Download The required file from s3
             echo "Downloading files from S3 bucket..."
-            location=${{ inputs.download_location }}
+            location="$DOWNLOAD_LOCATION"
             download_dir=$(realpath "$location")
-            echo "Downloading ${{ inputs.download_file }} at ==> ${download_dir}"
-            aws s3 cp s3://${{ inputs.s3_bucket }}/${{ inputs.download_file }} "$download_dir"
-            echo "Downloaded ${{ inputs.download_file }} to $download_dir"
+            echo "Downloading $DOWNLOAD_FILE at ==> ${download_dir}"
+            aws s3 cp "s3://$S3_BUCKET/$DOWNLOAD_FILE" "$download_dir"
+            echo "Downloaded $DOWNLOAD_FILE to $download_dir"
             ;;
           *)
             echo "Invalid mode. Use 'upload' or 'download'."

--- a/.github/actions/sync/action.yml
+++ b/.github/actions/sync/action.yml
@@ -25,6 +25,7 @@ runs:
         fetch-depth: 0
         ref: ${{ inputs.pr_ref }}
         repository: ${{ inputs.pr_repo }}
+        persist-credentials: false
 
     - name: Checkout master (push)
       if: ${{ (inputs.event_name == 'push' || inputs.event_name == 'workflow_call') && inputs.base_ref != '' }}
@@ -32,6 +33,7 @@ runs:
       with:
         fetch-depth: 0
         ref: ${{ inputs.base_ref }}
+        persist-credentials: false
 
     - name: Checkout current repo and ref (Fallback)
       if: ${{ (inputs.event_name == 'push' || inputs.event_name == 'workflow_call') && (inputs.base_ref == '' || inputs.pr_repo == '') }}
@@ -39,6 +41,7 @@ runs:
       with:
         fetch-depth: 0
         ref: ${{ github.ref }}
+        persist-credentials: false
 
     - name: Checkout for workflow_dispatch
       if: ${{ inputs.event_name == 'workflow_dispatch' }}
@@ -46,3 +49,4 @@ runs:
       with:
         fetch-depth: 0
         ref: ${{ inputs.base_ref }}
+        persist-credentials: false

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # This points to .github/workflows
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/doc_generator.yml
+++ b/.github/workflows/doc_generator.yml
@@ -5,13 +5,20 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # required to push generated docs to the gh-pages branch
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Install Doxygen
         run: sudo apt-get update && sudo apt-get install -y doxygen

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on:
@@ -23,6 +26,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: qualcomm/urm-image
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Hi all, 

I noticed the Actions security scan alerts on my previous PR. This is a follow up to address the vulnerabilities. Please promptly review #284 and this PR. Claude helped address all the issues:

Addresses all 33 findings from the enterprise zizmor scan:

- template-injection (23x, High) in actions/aws_s3_helper: move all attacker-controllable ${{ inputs.* }} (and github.workspace) expansions out of the run: shell into env: vars and reference them as quoted shell variables. Behavior is unchanged.
- artipacked (7x, Medium): set persist-credentials: false on all checkouts in actions/sync, codeql.yml, doc_generator.yml and pr.yml. None rely on the persisted git credential (doc_generator pushes to gh-pages with an explicit token in the remote URL).
- excessive-permissions (2x, Medium): add least-privilege permissions blocks (contents: read for pr.yml; contents: write scoped to the gh-pages deploy job in doc_generator.yml).
- dependabot-cooldown (1x, Medium): add a 7-day cooldown to the github-actions ecosystem in dependabot.yaml.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>